### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm install && npm start"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/gsilvamartin/rtcode/graphs/contributors">contributors</a>
   </sub>
 </p>
-[![Run on Repl.it](https://repl.it/badge/github/gsilvamartin/RTCode)](https://repl.it/github/gsilvamartin/RTCode)
+<a href="https://repl.it/github/gsilvamartin/RTCode"><img src="https://repl.it/badge/github/gsilvamartin/RTCode"></a>
 
 ## About RTCode
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     <a href="https://github.com/gsilvamartin/rtcode/graphs/contributors">contributors</a>
   </sub>
 </p>
+[![Run on Repl.it](https://repl.it/badge/github/gsilvamartin/RTCode)](https://repl.it/github/gsilvamartin/RTCode)
 
 ## About RTCode
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@PDanielY/RTCode).